### PR TITLE
Contribuir: Leve mejora a la lista de navegación

### DIFF
--- a/portafolio-dw/css/header.css
+++ b/portafolio-dw/css/header.css
@@ -20,10 +20,20 @@ width: auto;
      margin-right: 5px;
      font-size: var(--text-base);
      text-decoration: none;
+     margin-right: 15px;
+ }
+
+ nav a:hover{
+     color: rgb(136, 136, 136);
  }
 .header h1 {
     font-size: var(--text-title);
-    color: var(--colorWhite); 
+    color: var(--colorWhite);
+}
+
+.header img{
+    max-width: 100px;
+    padding: 10px;
 }
 /*End*/
 


### PR DESCRIPTION
Hay que separar los elementos del header, para que al añadir espaciado entre la lista de navegación, no se pierda el centrado de elementos en pantallas de resolución xl. 

Slds! 